### PR TITLE
Update ProductPartition to retrieve ProductDimension types and values

### DIFF
--- a/v201603/ad_group_criterion.go
+++ b/v201603/ad_group_criterion.go
@@ -164,7 +164,6 @@ func (s AdGroupCriterionService) Get(selector Selector) (adGroupCriterions AdGro
 	}{}
 	err = xml.Unmarshal([]byte(respBody), &getResp)
 	if err != nil {
-		fmt.Println(err)
 		return adGroupCriterions, totalCount, err
 	}
 	return getResp.AdGroupCriterions, getResp.Size, err

--- a/v201603/ad_group_criterion.go
+++ b/v201603/ad_group_criterion.go
@@ -14,7 +14,7 @@ func NewAdGroupCriterionService(auth *Auth) *AdGroupCriterionService {
 }
 
 type QualityInfo struct {
-	QualityScore                   int64 `xml:"qualityScore,omitempty"`
+	QualityScore int64 `xml:"qualityScore,omitempty"`
 }
 
 type CpcAmount struct {
@@ -164,6 +164,7 @@ func (s AdGroupCriterionService) Get(selector Selector) (adGroupCriterions AdGro
 	}{}
 	err = xml.Unmarshal([]byte(respBody), &getResp)
 	if err != nil {
+		fmt.Println(err)
 		return adGroupCriterions, totalCount, err
 	}
 	return getResp.AdGroupCriterions, getResp.Size, err

--- a/v201603/criterion.go
+++ b/v201603/criterion.go
@@ -149,11 +149,27 @@ type Address struct {
 	CountryCode    string `xml:"countryCode"`
 }
 
+type ProductDimension struct {
+	Type  string `xml:"ProductDimension.Type"`
+	Value string `xml:"value"`
+}
+
+//func (p ProductDimension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
+//	dimensionType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
+//	if err != nil {
+//		return err
+//	}
+//
+//	p.Type = dimensionType
+//	return nil
+//}
+
 type ProductPartition struct {
-	Id                int64  `xml:"id,omitempty"`
-	CriteriaType      string `xml:"type"`
-	PartitionType     string `xml:"partitionType,omitempty"`
-	ParentCriterionId int64  `xml:"parentCriterionId,omitempty"`
+	Id                int64            `xml:"id,omitempty"`
+	CriteriaType      string           `xml:"type"`
+	PartitionType     string           `xml:"partitionType,omitempty"`
+	ParentCriterionId int64            `xml:"parentCriterionId,omitempty"`
+	Dimension         ProductDimension `xml:"caseValue"`
 }
 
 // RadiusDistanceUnits: KILOMETERS, MILES

--- a/v201603/criterion.go
+++ b/v201603/criterion.go
@@ -154,16 +154,6 @@ type ProductDimension struct {
 	Value string `xml:"value"`
 }
 
-//func (p ProductDimension) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) error {
-//	dimensionType, err := findAttr(start.Attr, xml.Name{Space: "http://www.w3.org/2001/XMLSchema-instance", Local: "type"})
-//	if err != nil {
-//		return err
-//	}
-//
-//	p.Type = dimensionType
-//	return nil
-//}
-
 type ProductPartition struct {
 	Id                int64            `xml:"id,omitempty"`
 	CriteriaType      string           `xml:"type"`


### PR DESCRIPTION
This PR adds a ProductDimension property to a ProductPartition:

`type ProductDimension struct {
    Type  string`xml:"ProductDimension.Type"`
    Value string`xml:"value"`
}

type ProductPartition struct {
    Id                int64            `xml:"id,omitempty"`
    CriteriaType      string           `xml:"type"`
    PartitionType     string           `xml:"partitionType,omitempty"`
    ParentCriterionId int64            `xml:"parentCriterionId,omitempty"`
    Dimension         ProductDimension `xml:"caseValue"`
}`

which can be selected via Selector property "CaseValue".

This is necessary to build partition trees via this library
