### PR TITLE
Add additional DimensionType property to ProductDimension

### DIFF
--- a/v201603/ad_group_ad.go
+++ b/v201603/ad_group_ad.go
@@ -23,7 +23,7 @@ type TextAd struct {
 	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
 	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
 	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type 				 string            `xml:"type,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
 	DevicePreference     int64             `xml:"devicePreference,omitempty"`
 	Headline             string            `xml:"headline"`
 	Description1         string            `xml:"description1"`
@@ -45,7 +45,7 @@ type ImageAd struct {
 	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
 	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
 	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type 				 string            `xml:"type,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
 	DevicePreference     int64             `xml:"devicePreference,omitempty"`
 	Image                int64             `xml:"imageId"`
 	Name                 string            `xml:"name"`
@@ -67,7 +67,7 @@ type MobileAd struct {
 	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
 	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
 	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type 				 string            `xml:"type,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
 	DevicePreference     int64             `xml:"devicePreference,omitempty"`
 	Headline             string            `xml:"headline"`
 	Description          string            `xml:"description"`
@@ -105,7 +105,7 @@ type TemplateAd struct {
 	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
 	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
 	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type 				 string            `xml:"type,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
 	DevicePreference     int64             `xml:"devicePreference,omitempty"`
 	TemplateId           int64             `xml:"templateId"`
 	AdUnionId            int64             `xml:"adUnionId>id"`
@@ -131,7 +131,7 @@ type DynamicSearchAd struct {
 	FinalAppUrls         []AppUrl          `xml:"finalAppUrls,omitempty"`
 	TrackingUrlTemplate  string            `xml:"trackingUrlTemplate,omitempty"`
 	UrlCustomParameters  *CustomParameters `xml:"urlCustomParameters,omitempty"`
-	Type 				 string            `xml:"type,omitempty"`
+	Type                 string            `xml:"type,omitempty"`
 	DevicePreference     int64             `xml:"devicePreference,omitempty"`
 	Status               string            `xml:"-"`
 	ApprovalStatus       string            `xml:"-"`
@@ -142,7 +142,7 @@ type DynamicSearchAd struct {
 type ProductAd struct {
 	AdGroupId            int64    `xml:"-"`
 	Id                   int64    `xml:"id,omitempty"`
-	Type 				 string            `xml:"type,omitempty"`
+	Type                 string   `xml:"type,omitempty"`
 	Status               string   `xml:"-"`
 	ApprovalStatus       string   `xml:"-"`
 	DisapprovalReasons   []string `xml:"-"`

--- a/v201603/adwords_user_list.go
+++ b/v201603/adwords_user_list.go
@@ -1,8 +1,8 @@
 package v201603
 
 import (
-	"encoding/xml"
 	sha256 "crypto/sha256"
+	"encoding/xml"
 	"fmt"
 	"io"
 )
@@ -54,19 +54,19 @@ type Rule struct {
 }
 
 type UserListOperations struct {
-	XMLName 	xml.Name
-	Operations 	[]Operation 	`xml:"operations"`
+	XMLName    xml.Name
+	Operations []Operation `xml:"operations"`
 }
 
 type MutateMembersOperations struct {
-	XMLName 	xml.Name
-	Operations 	[]Operation 	`xml:"operations"`
+	XMLName    xml.Name
+	Operations []Operation `xml:"operations"`
 }
 
 type MutateMembersOperand struct {
-	UserListId 	int64 		`xml:"userListId"`
-	DataType 	string 		`xml:"dataType"`
-	Members 	[]string 	`xml:"members"`
+	UserListId int64    `xml:"userListId"`
+	DataType   string   `xml:"dataType"`
+	Members    []string `xml:"members"`
 }
 
 type UserList struct {
@@ -104,10 +104,10 @@ type UserList struct {
 	SeedListSize            *int64  `xml:"seedListSize,omitempty"`
 
 	// CrmBasedUserList
-	OptOutLink	*string 	`xml:"optOutLink,omitempty"`
+	OptOutLink *string `xml:"optOutLink,omitempty"`
 
 	// Keep track of xsi:type for mutate and mutateMembers
-	Xsi_type  	string 			`xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+	Xsi_type string `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
 }
 
 // DoubleClick platform user list mapped to AdWords
@@ -123,7 +123,7 @@ func NewLogicalUserList(name, description, status, integrationCode string, membe
 		IntegrationCode:    integrationCode,
 		MembershipLifeSpan: membershipLifeSpan,
 		LogicalRules:       &logicalRules,
-		Xsi_type: 			"LogicalUserList",
+		Xsi_type:           "LogicalUserList",
 	}
 }
 
@@ -135,7 +135,7 @@ func NewBasicUserList(name, description, status, integrationCode string, members
 		IntegrationCode:    integrationCode,
 		MembershipLifeSpan: membershipLifeSpan,
 		ConversionTypes:    &conversionTypes,
-		Xsi_type: 			"BasicUserList",
+		Xsi_type:           "BasicUserList",
 	}
 }
 
@@ -149,7 +149,7 @@ func NewDateSpecificRuleUserList(name, description, status, integrationCode stri
 		Rule:               &rule,
 		StartDate:          &startDate,
 		EndDate:            &endDate,
-		Xsi_type: 			"DateSpecificRuleUserList",
+		Xsi_type:           "DateSpecificRuleUserList",
 	}
 }
 
@@ -161,7 +161,7 @@ func NewExpressionRuleUserList(name, description, status, integrationCode string
 		IntegrationCode:    integrationCode,
 		MembershipLifeSpan: membershipLifeSpan,
 		Rule:               &rule,
-		Xsi_type: 			"ExpressionRuleUserList",
+		Xsi_type:           "ExpressionRuleUserList",
 	}
 }
 
@@ -172,7 +172,7 @@ func NewSimilarUserList(name, description, status, integrationCode string, membe
 		Status:             status,
 		IntegrationCode:    integrationCode,
 		MembershipLifeSpan: membershipLifeSpan,
-		Xsi_type: 			"SimilarUserList",
+		Xsi_type:           "SimilarUserList",
 	}
 }
 
@@ -181,15 +181,14 @@ func NewCrmBasedUserList(name, description string, membershipLifeSpan int64, opt
 		Name:               name,
 		Description:        description,
 		MembershipLifeSpan: membershipLifeSpan,
-		OptOutLink: 		&optOutLink,
-		Xsi_type: 			"CrmBasedUserList",
+		OptOutLink:         &optOutLink,
+		Xsi_type:           "CrmBasedUserList",
 	}
 }
 
 func NewMutateMembersOperand() *MutateMembersOperand {
 	return &MutateMembersOperand{DataType: "EMAIL_SHA256"}
 }
-
 
 // Get returns an array of adwords user lists and the total number of adwords user lists matching
 // the selector.
@@ -268,7 +267,7 @@ func (s AdwordsUserListService) Get(selector Selector) (userLists []UserList, er
 }
 
 // Mutate adds/sets a collection of user lists. Returns a list of User Lists
-// 
+//
 // Example
 // 	auls := gads.NewAdwordsUserListService(&config.Auth)
 //
@@ -290,12 +289,12 @@ func (s AdwordsUserListService) Get(selector Selector) (userLists []UserList, er
 //     https://developers.google.com/adwords/api/docs/reference/v201603/AdwordsUserListService#mutate
 //
 func (s *AdwordsUserListService) Mutate(userListOperations UserListOperations) (adwordsUserLists []UserList, err error) {
-	
+
 	userListOperations.XMLName = xml.Name{
-			Space: baseRemarketingUrl,
-			Local: "mutate",
-		}
-	
+		Space: baseRemarketingUrl,
+		Local: "mutate",
+	}
+
 	respBody, err := s.Auth.request(adwordsUserListServiceUrl, "mutate", userListOperations)
 	if err != nil {
 		return adwordsUserLists, err
@@ -311,7 +310,7 @@ func (s *AdwordsUserListService) Mutate(userListOperations UserListOperations) (
 	return mutateResp.AdwordsUserLists, err
 }
 
-// Mutate adds/removes members/emails to specified user list. 
+// Mutate adds/removes members/emails to specified user list.
 // Note: Only 1 operation per userListId
 //
 // Example
@@ -341,10 +340,10 @@ func (s *AdwordsUserListService) Mutate(userListOperations UserListOperations) (
 //
 func (s *AdwordsUserListService) MutateMembers(mutateMembersOperations MutateMembersOperations) (adwordsUserLists []UserList, err error) {
 	mutateMembersOperations.XMLName = xml.Name{
-			Space: baseRemarketingUrl,
-			Local: "mutateMembers",
-		}
-	
+		Space: baseRemarketingUrl,
+		Local: "mutateMembers",
+	}
+
 	respBody, err := s.Auth.request(adwordsUserListServiceUrl, "mutateMembers", mutateMembersOperations)
 	if err != nil {
 		return adwordsUserLists, err

--- a/v201603/batch_job.go
+++ b/v201603/batch_job.go
@@ -2,8 +2,8 @@ package v201603
 
 import (
 	"encoding/xml"
-	"strings"
 	"fmt"
+	"strings"
 )
 
 type BatchJobService struct {
@@ -11,8 +11,8 @@ type BatchJobService struct {
 }
 
 type BatchJobPage struct {
-	TotalNumEntries 	int 		`xml:"rval>totalNumEntries"`
-	BatchJobs 			[]BatchJob 	`xml:"rval>entries"`
+	TotalNumEntries int        `xml:"rval>totalNumEntries"`
+	BatchJobs       []BatchJob `xml:"rval>entries"`
 }
 
 type BatchJobOperations struct {
@@ -20,52 +20,52 @@ type BatchJobOperations struct {
 }
 
 type Operation struct {
-	Operator   	string   		`xml:"https://adwords.google.com/api/adwords/cm/v201603 operator"`
-	Operand 	interface{}		`xml:"operand"`
-	Xsi_type  	string 			`xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
+	Operator string      `xml:"https://adwords.google.com/api/adwords/cm/v201603 operator"`
+	Operand  interface{} `xml:"operand"`
+	Xsi_type string      `xml:"http://www.w3.org/2001/XMLSchema-instance type,attr,omitempty"`
 }
 
 type BatchJobOperation struct {
-	Operator 	string 		`xml:"operator"`
-	Operand 	BatchJob 	`xml:"operand"`
+	Operator string   `xml:"operator"`
+	Operand  BatchJob `xml:"operand"`
 }
 
 type BatchJob struct {
-	Id 					int64 						`xml:"id,omitempty" json:",string"`
-	Status 				string 						`xml:"status,omitempty"`
-	ProgressStats 		*ProgressStats 				`xml:"progressStats,omitempty"`
-	UploadUrl 			*TemporaryUrl 				`xml:"uploadUrl,omitempty"`
-	DownloadUrl 		*TemporaryUrl 				`xml:"downloadUrl,omitempty"`
-	ProcessingErrors 	*BatchJobProcessingError 	`xml:"processingErrors,omitempty"`
+	Id               int64                    `xml:"id,omitempty" json:",string"`
+	Status           string                   `xml:"status,omitempty"`
+	ProgressStats    *ProgressStats           `xml:"progressStats,omitempty"`
+	UploadUrl        *TemporaryUrl            `xml:"uploadUrl,omitempty"`
+	DownloadUrl      *TemporaryUrl            `xml:"downloadUrl,omitempty"`
+	ProcessingErrors *BatchJobProcessingError `xml:"processingErrors,omitempty"`
 }
 
 type TemporaryUrl struct {
-	Url 		string 	`xml:"url"`
-	Expiration 	string 	`xml:"expiration,"`
+	Url        string `xml:"url"`
+	Expiration string `xml:"expiration,"`
 }
 
 type BatchJobProcessingError struct {
-	FieldPath 		string 	`xml:"fieldPath"`
-	Trigger 		string 	`xml:"trigger"`
-	ErrorString 	string 	`xml:"errorString"`
-	Reason 			string 	`xml:"reason"`
+	FieldPath   string `xml:"fieldPath"`
+	Trigger     string `xml:"trigger"`
+	ErrorString string `xml:"errorString"`
+	Reason      string `xml:"reason"`
 }
 
 type ProgressStats struct {
-	NumOperationsExecuted 		int64 	`xml:"numOperationsExecuted" json:",string"`
-	NumOperationsSucceeded 		int64 	`xml:"numOperationsSucceeded" json:",string"`
-	EstimatedPercentExecuted 	int 	`xml:"estimatedPercentExecuted"`
-	NumResultsWritten 			int64 	`xml:"numResultsWritten" json:",string"`
+	NumOperationsExecuted    int64 `xml:"numOperationsExecuted" json:",string"`
+	NumOperationsSucceeded   int64 `xml:"numOperationsSucceeded" json:",string"`
+	EstimatedPercentExecuted int   `xml:"estimatedPercentExecuted"`
+	NumResultsWritten        int64 `xml:"numResultsWritten" json:",string"`
 }
 
 type MutateResults struct {
-	Result 		MutateResult 	`xml:"result"`
-	ErrorList 	[]MutateErrors 	`xml:"errorList"`
-	Index 		int 			`xml:"index"`
+	Result    MutateResult   `xml:"result"`
+	ErrorList []MutateErrors `xml:"errorList"`
+	Index     int            `xml:"index"`
 }
 
 type MutateErrors struct {
-	Errors 		EntityError 	`xml:"errors"`
+	Errors EntityError `xml:"errors"`
 }
 
 type MutateResult interface{}
@@ -114,9 +114,9 @@ func (s *BatchJobService) Get(selector Selector) (batchJobPage BatchJobPage, err
 	if err != nil {
 		return batchJobPage, err
 	}
-	
+
 	err = xml.Unmarshal([]byte(respBody), &batchJobPage)
-	
+
 	return batchJobPage, err
 }
 
@@ -137,7 +137,7 @@ func (s *BatchJobService) Get(selector Selector) (batchJobPage BatchJobPage, err
 //
 // 	https://developers.google.com/adwords/api/docs/reference/v201603/BatchJobService#mutate
 func (s *BatchJobService) Mutate(batchJobOperations BatchJobOperations) (batchJobs []BatchJob, err error) {
-	
+
 	mutation := struct {
 		XMLName xml.Name
 		Ops     []BatchJobOperation `xml:"operations"`
@@ -163,7 +163,7 @@ func (s *BatchJobService) Mutate(batchJobOperations BatchJobOperations) (batchJo
 }
 
 func (s *BatchJobService) Query() {
-	
+
 }
 
 func (mr *MutateResults) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) (err error) {
@@ -266,33 +266,33 @@ func (mr *MutateResults) UnmarshalXML(dec *xml.Decoder, start xml.StartElement) 
 // getXsiType validates the schema instance type and returns it since Bulk Mutate requires it to be set
 func getXsiType(objectName string) (string, bool) {
 	switch {
-		case strings.Contains(objectName, "AdGroupAdLabelOperation"):
-			return "AdGroupAdLabelOperation", true
-		case strings.Contains(objectName, "AdGroupAdOperation"):
-			return "AdGroupAdOperation", true
-		case strings.Contains(objectName, "AdGroupBidModifierOperation"):
-			return "AdGroupBidModifierOperation", true
-		case strings.Contains(objectName, "AdGroupCriterionLabelOperation"):
-			return "AdGroupCriterionLabelOperation", true
-		case strings.Contains(objectName, "AdGroupCriterionOperation"):
-			return "AdGroupCriterionOperation", true
-		case strings.Contains(objectName, "AdGroupLabelOperation"):
-			return "AdGroupLabelOperation", true
-		case strings.Contains(objectName, "AdGroupOperation"):
-			return "AdGroupOperation", true
-		case strings.Contains(objectName, "BudgetOperation"):
-			return "BudgetOperation", true
-		case strings.Contains(objectName, "CampaignAdExtensionOperation"):
-			return "CampaignAdExtensionOperation", true
-		case strings.Contains(objectName, "CampaignCriterionOperation"):
-			return "CampaignCriterionOperation", true
-		case strings.Contains(objectName, "CampaignLabelOperation"):
-			return "CampaignLabelOperation", true
-		case strings.Contains(objectName, "CampaignOperation"):
-			return "CampaignOperation", true
-		case strings.Contains(objectName, "FeedItemOperation"):
-			return "FeedItemOperation", true
-		default:
-			return "", false
+	case strings.Contains(objectName, "AdGroupAdLabelOperation"):
+		return "AdGroupAdLabelOperation", true
+	case strings.Contains(objectName, "AdGroupAdOperation"):
+		return "AdGroupAdOperation", true
+	case strings.Contains(objectName, "AdGroupBidModifierOperation"):
+		return "AdGroupBidModifierOperation", true
+	case strings.Contains(objectName, "AdGroupCriterionLabelOperation"):
+		return "AdGroupCriterionLabelOperation", true
+	case strings.Contains(objectName, "AdGroupCriterionOperation"):
+		return "AdGroupCriterionOperation", true
+	case strings.Contains(objectName, "AdGroupLabelOperation"):
+		return "AdGroupLabelOperation", true
+	case strings.Contains(objectName, "AdGroupOperation"):
+		return "AdGroupOperation", true
+	case strings.Contains(objectName, "BudgetOperation"):
+		return "BudgetOperation", true
+	case strings.Contains(objectName, "CampaignAdExtensionOperation"):
+		return "CampaignAdExtensionOperation", true
+	case strings.Contains(objectName, "CampaignCriterionOperation"):
+		return "CampaignCriterionOperation", true
+	case strings.Contains(objectName, "CampaignLabelOperation"):
+		return "CampaignLabelOperation", true
+	case strings.Contains(objectName, "CampaignOperation"):
+		return "CampaignOperation", true
+	case strings.Contains(objectName, "FeedItemOperation"):
+		return "FeedItemOperation", true
+	default:
+		return "", false
 	}
 }

--- a/v201603/batch_job_helper.go
+++ b/v201603/batch_job_helper.go
@@ -1,14 +1,14 @@
 package v201603
 
 import (
-	"reflect"
-	"encoding/xml"
 	"bytes"
-	"net/http"
-	"io/ioutil"
+	"encoding/xml"
 	"errors"
-	"os"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
 )
 
 type BatchJobHelper struct {
@@ -22,7 +22,7 @@ func NewBatchJobHelper(auth *Auth) *BatchJobHelper {
 //	UploadBatchJobOperations uploads batch operations to an BatchJob.UploadUrl from BatchJobService.Mutate
 //
 //	Example
-//	
+//
 //	ago := gads.AdGroupOperations{
 //			"ADD": {
 //				gads.AdGroup{
@@ -41,7 +41,7 @@ func NewBatchJobHelper(auth *Auth) *BatchJobHelper {
 //	var operations []interface{}
 //	operations = append(operations, ago)
 //	err = batchJobHelper.UploadBatchJobOperations(operations, UploadUrl)
-// 		
+//
 //
 //	https://developers.google.com/adwords/api/docs/guides/batch-jobs?hl=en#upload_operations_to_the_upload_url
 func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, url TemporaryUrl) (err error) {
@@ -50,33 +50,33 @@ func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, u
 	for _, operation := range jobOperations {
 		if operationType, valid := getXsiType(reflect.ValueOf(operation).Type().String()); valid {
 			switch reflect.TypeOf(operation).Kind() {
-			    case reflect.Map:
-			        ops := reflect.ValueOf(operation)
+			case reflect.Map:
+				ops := reflect.ValueOf(operation)
 
-			        keys := ops.MapKeys()
+				keys := ops.MapKeys()
 
-			        for _, action := range keys {
-			        	jobs := ops.MapIndex(action)
+				for _, action := range keys {
+					jobs := ops.MapIndex(action)
 
-			        	for i := 0; i < jobs.Len(); i++ {
-				            
-				            operations = append(operations,
-								Operation{
-									Operator:   action.String(),
-									Operand: 	jobs.Index(i).Interface(),
-									Xsi_type: 	operationType,
-								},
-							)
-				        }
+					for i := 0; i < jobs.Len(); i++ {
+
+						operations = append(operations,
+							Operation{
+								Operator: action.String(),
+								Operand:  jobs.Index(i).Interface(),
+								Xsi_type: operationType,
+							},
+						)
 					}
-	    	}
-	    }
+				}
+			}
+		}
 	}
 
 	if len(operations) > 0 {
 		mutation := struct {
 			XMLName xml.Name
-			Ops     []Operation 			`xml:"operations"`
+			Ops     []Operation `xml:"operations"`
 		}{
 			XMLName: xml.Name{
 				Space: baseUrl,
@@ -92,13 +92,13 @@ func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, u
 		if err != nil {
 			return err
 		}
-		
-    	req.Header.Set("Content-Type", "application/xml")
-    	req.Header.Set("Content-Length", "0")
-    	req.Header.Set("x-goog-resumable", "start")
 
-    	response, err := client.Do(req)
-		
+		req.Header.Set("Content-Type", "application/xml")
+		req.Header.Set("Content-Length", "0")
+		req.Header.Set("x-goog-resumable", "start")
+
+		response, err := client.Do(req)
+
 		if err != nil {
 			return err
 		}
@@ -113,9 +113,9 @@ func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, u
 			return errors.New(fmt.Sprintf("Invalid response received. %v received. Body: %v", response.StatusCode, string(respBody)))
 		}
 
-    	location := response.Header.Get("Location")
+		location := response.Header.Get("Location")
 
-		reqBody, err := xml.MarshalIndent(mutation,"  ", "  ")
+		reqBody, err := xml.MarshalIndent(mutation, "  ", "  ")
 		bodyLength := len(reqBody)
 
 		if err != nil {
@@ -123,18 +123,18 @@ func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, u
 		}
 
 		req, err = http.NewRequest("PUT", location, bytes.NewReader(reqBody))
-		
+
 		if err != nil {
 			return err
 		}
-		
-		// Set headers for incremental upload
-    	req.Header.Set("Content-Type", "application/xml")
-    	req.Header.Set("Content-Length", string(bodyLength))
-    	req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%v/%v", bodyLength-1, bodyLength))
 
-    	resp, err := client.Do(req)
-		
+		// Set headers for incremental upload
+		req.Header.Set("Content-Type", "application/xml")
+		req.Header.Set("Content-Length", string(bodyLength))
+		req.Header.Set("Content-Range", fmt.Sprintf("bytes 0-%v/%v", bodyLength-1, bodyLength))
+
+		resp, err := client.Do(req)
+
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, u
 		}
 
 		// resp seems to only return 200's and there is no error handling, but if we happen to get invalid status lets try to do something with it
-		if resp.StatusCode != 200 {	
+		if resp.StatusCode != 200 {
 			return errors.New("Non-200 response returned Body: " + string(respBody))
 		}
 	}
@@ -162,13 +162,13 @@ func (s *BatchJobHelper) UploadBatchJobOperations(jobOperations []interface{}, u
 //	DownloadBatchJob download batch operations from an BatchJob.DownloadUrl from BatchJobService.Get
 //
 //	Example
-//	
+//
 //	mutateResult, err := batchJobHelper.DownloadBatchJob(*batchJobs.BatchJobs[0].DownloadUrl)
 //
 //	https://developers.google.com/adwords/api/docs/guides/batch-jobs?hl=en#download_the_batch_job_results_and_check_for_errors
 func (s *BatchJobHelper) DownloadBatchJob(url TemporaryUrl) (mutateResults []MutateResults, err error) {
 	resp, err := http.Get(url.Url)
-		
+
 	if err != nil {
 		return mutateResults, err
 	}
@@ -181,7 +181,7 @@ func (s *BatchJobHelper) DownloadBatchJob(url TemporaryUrl) (mutateResults []Mut
 	}
 
 	soapResp := struct {
-		MutateResults    []MutateResults   `xml:"rval"`
+		MutateResults []MutateResults `xml:"rval"`
 	}{}
 
 	err = xml.Unmarshal([]byte(respBody), &soapResp)

--- a/v201603/campaign.go
+++ b/v201603/campaign.go
@@ -361,7 +361,7 @@ func (s *CampaignService) MutateLabel(campaignLabelOperations CampaignLabelOpera
 //     https://developers.google.com/adwords/api/docs/reference/v201409/CampaignService#query
 //
 func (s *CampaignService) Query(query string) (campaigns []Campaign, totalCount int64, err error) {
-	
+
 	respBody, err := s.Auth.request(
 		campaignServiceUrl,
 		"query",
@@ -379,7 +379,7 @@ func (s *CampaignService) Query(query string) (campaigns []Campaign, totalCount 
 	}
 
 	getResp := struct {
-		Size     int64     `xml:"rval>totalNumEntries"`
+		Size      int64      `xml:"rval>totalNumEntries"`
 		Campaigns []Campaign `xml:"rval>entries"`
 	}{}
 

--- a/v201603/criterion.go
+++ b/v201603/criterion.go
@@ -150,8 +150,9 @@ type Address struct {
 }
 
 type ProductDimension struct {
-	Type  string `xml:"ProductDimension.Type"`
-	Value string `xml:"value"`
+	Type          string `xml:"ProductDimension.Type"`
+	DimensionType string `xml:"type"`
+	Value         string `xml:"value"`
 }
 
 type ProductPartition struct {

--- a/v201603/data.go
+++ b/v201603/data.go
@@ -13,31 +13,31 @@ func NewDataService(auth *Auth) *DataService {
 }
 
 type LandscapePoint struct {
-	Bid  					*int64 		`xml:"bid>microAmount,omitempty"`
-	Clicks 					*int64 		`xml:"clicks,omitempty"`
-	Cost 					*int64 		`xml:"cost>microAmount,omitempty"`
-	Impressions 			*int64 		`xml:"impressions,omitempty"`
-	PromotedImpressions 	*int64 		`xml:"promotedImpressions,omitempty"`
+	Bid                 *int64 `xml:"bid>microAmount,omitempty"`
+	Clicks              *int64 `xml:"clicks,omitempty"`
+	Cost                *int64 `xml:"cost>microAmount,omitempty"`
+	Impressions         *int64 `xml:"impressions,omitempty"`
+	PromotedImpressions *int64 `xml:"promotedImpressions,omitempty"`
 }
 
 type BidLandscape struct {
-	CampaignId 			*int64 				`xml:"campaignId,omitempty"`
-	AdGroupId 			*int64 				`xml:"adGroupId,omitempty"`
-	StartDate 			*string 			`xml:"startDate,omitempty"`
-	EndDate 			*string 			`xml:"endDate,omitempty"`
-	LandscapePoints 	[]LandscapePoint 	`xml:"landscapePoints"`
+	CampaignId      *int64           `xml:"campaignId,omitempty"`
+	AdGroupId       *int64           `xml:"adGroupId,omitempty"`
+	StartDate       *string          `xml:"startDate,omitempty"`
+	EndDate         *string          `xml:"endDate,omitempty"`
+	LandscapePoints []LandscapePoint `xml:"landscapePoints"`
 }
 
 type AdGroupBidLandscape struct {
 	BidLandscape
-	Type 				string 		`xml:"type"`
-	LandscapeCurrent 	bool 		`xml:"landscapeCurrent"`
-	Errors              []error     `xml:"-"`
+	Type             string  `xml:"type"`
+	LandscapeCurrent bool    `xml:"landscapeCurrent"`
+	Errors           []error `xml:"-"`
 }
 
 type CriterionBidLandscape struct {
 	BidLandscape
-	CriterionId 			*int64 				`xml:"criterionId,omitempty"`
+	CriterionId *int64 `xml:"criterionId,omitempty"`
 }
 
 // GetAdGroupBidLandscape returns an array of AdGroupBidLandscape objects
@@ -98,8 +98,8 @@ func (s *DataService) GetAdGroupBidLandscape(selector Selector) (adGroupBidLands
 		return adGroupBidLandscapes, totalCount, err
 	}
 	getResp := struct {
-		Size      				int64      `xml:"rval>totalNumEntries"`
-		AdGroupBidLandscapes 	[]AdGroupBidLandscape `xml:"rval>entries"`
+		Size                 int64                 `xml:"rval>totalNumEntries"`
+		AdGroupBidLandscapes []AdGroupBidLandscape `xml:"rval>entries"`
 	}{}
 	err = xml.Unmarshal([]byte(respBody), &getResp)
 	if err != nil {
@@ -167,8 +167,8 @@ func (s *DataService) GetCriterionBidLandscape(selector Selector) (criterionBidL
 		return criterionBidLandscapes, totalCount, err
 	}
 	getResp := struct {
-		Size      				int64      `xml:"rval>totalNumEntries"`
-		CriterionBidLandscapes 	[]CriterionBidLandscape `xml:"rval>entries"`
+		Size                   int64                   `xml:"rval>totalNumEntries"`
+		CriterionBidLandscapes []CriterionBidLandscape `xml:"rval>entries"`
 	}{}
 	err = xml.Unmarshal([]byte(respBody), &getResp)
 	if err != nil {
@@ -184,7 +184,7 @@ func (s *DataService) GetCriterionBidLandscape(selector Selector) (criterionBidL
 //     https://developers.google.com/adwords/api/docs/reference/v201603/DataService#queryadgroupbidlandscape
 //
 func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscapes []AdGroupBidLandscape, totalCount int64, err error) {
-	
+
 	respBody, err := s.Auth.request(
 		dataServiceUrl,
 		"queryAdGroupBidLandscape",
@@ -202,7 +202,7 @@ func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscap
 	}
 
 	getResp := struct {
-		Size     int64     `xml:"rval>totalNumEntries"`
+		Size                 int64                 `xml:"rval>totalNumEntries"`
 		AdGroupBidLandscapes []AdGroupBidLandscape `xml:"rval>entries"`
 	}{}
 
@@ -220,7 +220,7 @@ func (s *DataService) QueryAdGroupBidLandscape(query string) (adGroupBidLandscap
 //     https://developers.google.com/adwords/api/docs/reference/v201603/DataService#querycriterionbidlandscape
 //
 func (s *DataService) QueryCriterionBidLandscape(query string) (criterionBidLandscapes []CriterionBidLandscape, totalCount int64, err error) {
-	
+
 	respBody, err := s.Auth.request(
 		dataServiceUrl,
 		"queryCriterionBidLandscape",
@@ -238,7 +238,7 @@ func (s *DataService) QueryCriterionBidLandscape(query string) (criterionBidLand
 	}
 
 	getResp := struct {
-		Size     int64     `xml:"rval>totalNumEntries"`
+		Size                   int64                   `xml:"rval>totalNumEntries"`
 		CriterionBidLandscapes []CriterionBidLandscape `xml:"rval>entries"`
 	}{}
 

--- a/v201603/report_download.go
+++ b/v201603/report_download.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/csv"
 	"encoding/xml"
+	"errors"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"errors"
 )
 
 type ReportDownloadService struct {
@@ -64,7 +64,7 @@ func (s *ReportDownloadService) AWQL(awql string, fmt string) (res interface{}, 
 		return res, err
 	}
 	return string(respBody), err*/
-	
+
 	// if we didn't get a 200 bubble up the error
 	if resp.StatusCode != 200 {
 		response, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
This PR adds DimensionType to ProductDimension (used by certain dimension types to determine additional typing on the struct)

Example can be found at https://developers.google.com/adwords/api/docs/reference/v201603/AdGroupCriterionService.ProductType#field

Also ran go fmt which fixed codestyle stuff across multiple files.
