### PR TITLE
Add ProductScope criterion

### DIFF
--- a/v201603/campaign_criterion.go
+++ b/v201603/campaign_criterion.go
@@ -1,11 +1,6 @@
 package v201603
 
-import (
-	//  "strings"
-	//  "strconv"
-	"encoding/xml"
-	"fmt"
-)
+import "encoding/xml"
 
 type CampaignCriterionService struct {
 	Auth
@@ -165,7 +160,6 @@ func (s *CampaignCriterionService) Get(selector Selector) (campaignCriterions Ca
 		Size               int64              `xml:"rval>totalNumEntries"`
 		CampaignCriterions CampaignCriterions `xml:"rval>entries"`
 	}{}
-	fmt.Printf("%s\n", respBody)
 	err = xml.Unmarshal([]byte(respBody), &getResp)
 	if err != nil {
 		return campaignCriterions, totalCount, err

--- a/v201603/criterion.go
+++ b/v201603/criterion.go
@@ -165,6 +165,12 @@ type ProductPartition struct {
 	Cpc               *Cpc             // This value is inherited from BiddableAdgroupCriterion
 }
 
+type ProductScope struct {
+	Id           int64              `xml:"id,omitempty"`
+	CriteriaType string             `xml:"type"`
+	Dimensions   []ProductDimension `xml:"dimensions"`
+}
+
 // RadiusDistanceUnits: KILOMETERS, MILES
 // RadiusUnits:
 type ProximityCriterion struct {
@@ -280,6 +286,10 @@ func criterionUnmarshalXML(dec *xml.Decoder, start xml.StartElement) (Criterion,
 		return c, err
 	case "ProductPartition":
 		c := ProductPartition{}
+		err := dec.DecodeElement(&c, &start)
+		return c, err
+	case "ProductScope":
+		c := ProductScope{}
 		err := dec.DecodeElement(&c, &start)
 		return c, err
 	case "Proximity":

--- a/v201603/criterion.go
+++ b/v201603/criterion.go
@@ -160,6 +160,7 @@ type ProductPartition struct {
 	PartitionType     string           `xml:"partitionType,omitempty"`
 	ParentCriterionId int64            `xml:"parentCriterionId,omitempty"`
 	Dimension         ProductDimension `xml:"caseValue"`
+	Cpc               *Cpc             // This value is inherited from BiddableAdgroupCriterion
 }
 
 // RadiusDistanceUnits: KILOMETERS, MILES


### PR DESCRIPTION
This PR adds ProductScope campaign criterion struct and unmarshalling. Also removed unnecessary fmt.Printf from campaign_criterion and associated imports.

@colinmutter do you have plans on updating the version to v201607? If not, could you make me a contributor on this project so I can begin transitioning the API version?

Thanks!
